### PR TITLE
feat(ui): add tooltips to icon-only buttons

### DIFF
--- a/packages/client/src/environment.tsx
+++ b/packages/client/src/environment.tsx
@@ -4,7 +4,18 @@ import { getRouteApi } from '@tanstack/react-router';
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { Ulid } from 'id128';
 import { Suspense } from 'react';
-import { Collection, Dialog, DialogTrigger, MenuTrigger, Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
+import {
+  Collection,
+  Dialog,
+  DialogTrigger,
+  MenuTrigger,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  Tooltip,
+  TooltipTrigger,
+} from 'react-aria-components';
 import { FiMoreHorizontal, FiPlus } from 'react-icons/fi';
 import { twJoin } from 'tailwind-merge';
 
@@ -104,9 +115,14 @@ export const EnvironmentsWidget = () => {
       <ImportDialog />
 
       <DialogTrigger>
-        <Button className={tw`p-1`} variant='ghost'>
-          <GlobalEnvironmentIcon className={tw`size-4 text-slate-500`} />
-        </Button>
+        <TooltipTrigger delay={750}>
+          <Button className={tw`p-1`} variant='ghost'>
+            <GlobalEnvironmentIcon className={tw`size-4 text-slate-500`} />
+          </Button>
+          <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>
+            Manage Variables & Environments
+          </Tooltip>
+        </TooltipTrigger>
 
         <Modal>
           <Dialog className={tw`outline-hidden h-full`}>
@@ -121,13 +137,18 @@ export const EnvironmentsWidget = () => {
                   <div className={tw`-order-1 mb-1 mt-3 flex items-center justify-between py-0.5`}>
                     <span className={tw`text-md leading-5 text-slate-400`}>Environments</span>
 
-                    <Button
-                      className={tw`bg-slate-200 p-0.5`}
-                      onPress={() => void environmentCreateMutation.mutate({ name: 'New Environment', workspaceId })}
-                      variant='ghost'
-                    >
-                      <FiPlus className={tw`size-4 text-slate-500`} />
-                    </Button>
+                    <TooltipTrigger delay={750}>
+                      <Button
+                        className={tw`bg-slate-200 p-0.5`}
+                        onPress={() => void environmentCreateMutation.mutate({ name: 'New Environment', workspaceId })}
+                        variant='ghost'
+                      >
+                        <FiPlus className={tw`size-4 text-slate-500`} />
+                      </Button>
+                      <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>
+                        Add New Environment
+                      </Tooltip>
+                    </TooltipTrigger>
                   </div>
 
                   <TabList className={tw`contents`} items={environments}>

--- a/packages/client/src/flow/nodes/request.tsx
+++ b/packages/client/src/flow/nodes/request.tsx
@@ -4,6 +4,7 @@ import { useSuspenseQueries } from '@tanstack/react-query';
 import { Position, useReactFlow } from '@xyflow/react';
 import { Ulid } from 'id128';
 import { use } from 'react';
+import { Tooltip, TooltipTrigger } from 'react-aria-components';
 import { FiExternalLink, FiX } from 'react-icons/fi';
 
 import { endpointGet } from '@the-dev-tools/spec/collection/item/endpoint/v1/endpoint-EndpointService_connectquery';
@@ -159,13 +160,16 @@ export const RequestPanel = ({ node: { nodeId, request } }: NodePanelProps) => {
 
         <div className={tw`ml-2 mr-3 h-5 w-px shrink-0 bg-slate-300`} />
 
-        <ButtonAsLink
-          className={tw`p-1`}
-          href={{ search: (_: Partial<FlowSearch>) => ({ ..._, node: undefined }), to: '.' }}
-          variant='ghost'
-        >
-          <FiX className={tw`size-5 text-slate-500`} />
-        </ButtonAsLink>
+        <TooltipTrigger delay={750}>
+          <ButtonAsLink
+            className={tw`p-1`}
+            href={{ search: (_: Partial<FlowSearch>) => ({ ..._, node: undefined }), to: '.' }}
+            variant='ghost'
+          >
+            <FiX className={tw`size-5 text-slate-500`} />
+          </ButtonAsLink>
+          <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>Close</Tooltip>
+        </TooltipTrigger>
       </div>
 
       <div className='shadow-xs m-5 mb-4 flex flex-1 items-center gap-3 rounded-lg border border-slate-300 px-3 py-2'>

--- a/packages/client/src/form-table.tsx
+++ b/packages/client/src/form-table.tsx
@@ -3,6 +3,7 @@ import { useReactTable } from '@tanstack/react-table';
 import { AccessorKeyColumnDef, DisplayColumnDef, RowData, Table, TableOptions } from '@tanstack/table-core';
 import { HashMap, Option, pipe, String } from 'effect';
 import { ReactNode, useEffect, useRef } from 'react';
+import { Tooltip, TooltipTrigger } from 'react-aria-components';
 import {
   FieldPath,
   FieldValues,
@@ -272,9 +273,12 @@ export const ColumnActionDelete = <I extends DescMessage, O extends DescMessage>
 }: ColumnActionDeleteProps<I, O>) => {
   const delete$ = useConnectMutation(schema);
   return (
-    <Button className={tw`text-red-700`} onPress={() => void delete$.mutateAsync(input)} variant='ghost'>
-      <LuTrash2 />
-    </Button>
+    <TooltipTrigger delay={750}>
+      <Button className={tw`text-red-700`} onPress={() => void delete$.mutateAsync(input)} variant='ghost'>
+        <LuTrash2 />
+      </Button>
+      <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>Delete</Tooltip>
+    </TooltipTrigger>
   );
 };
 
@@ -291,13 +295,16 @@ export const ColumnActionUndoDelta = <I extends DescMessage, O extends DescMessa
 }: ColumnActionUndoDeltaProps<I, O>) => {
   const delete$ = useConnectMutation(schema);
   return (
-    <Button
-      className={({ isDisabled }) => twJoin(tw`text-slate-500`, isDisabled && tw`invisible`)}
-      isDisabled={!hasDelta}
-      onPress={() => void delete$.mutateAsync(input)}
-      variant='ghost'
-    >
-      <RedoIcon />
-    </Button>
+    <TooltipTrigger delay={750}>
+      <Button
+        className={({ isDisabled }) => twJoin(tw`text-slate-500`, isDisabled && tw`invisible`)}
+        isDisabled={!hasDelta}
+        onPress={() => void delete$.mutateAsync(input)}
+        variant='ghost'
+      >
+        <RedoIcon />
+      </Button>
+      <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>Undo changes</Tooltip>
+    </TooltipTrigger>
   );
 };

--- a/packages/client/src/workspace/import.tsx
+++ b/packages/client/src/workspace/import.tsx
@@ -11,6 +11,8 @@ import {
   Table,
   TableBody,
   TableHeader,
+  Tooltip,
+  TooltipTrigger,
 } from 'react-aria-components';
 import { FiInfo, FiX } from 'react-icons/fi';
 import { twMerge } from 'tailwind-merge';
@@ -173,9 +175,14 @@ export const ImportDialog = () => {
 
   return (
     <DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
-      <Button className={tw`p-1`} variant='ghost'>
-        <FileImportIcon className={tw`size-4 text-slate-500`} />
-      </Button>
+      <TooltipTrigger delay={750}>
+        <Button className={tw`p-1`} variant='ghost'>
+          <FileImportIcon className={tw`size-4 text-slate-500`} />
+        </Button>
+        <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>
+          Import Collections and Flows
+        </Tooltip>
+      </TooltipTrigger>
 
       <Modal modalStyle={{ maxHeight: 'max(40vh, min(32rem, 90vh))', maxWidth: 'max(40vw, min(40rem, 90vw))' }}>
         <Dialog className={tw`outline-hidden flex h-full flex-col overflow-auto`}>

--- a/packages/client/src/workspace/layout.tsx
+++ b/packages/client/src/workspace/layout.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, Outlet, redirect, useMatchRoute, useNavigate } from '@
 import { pipe, Schema } from 'effect';
 import { Ulid } from 'id128';
 import { RefObject, useRef } from 'react';
-import { ListBox, MenuTrigger, Text } from 'react-aria-components';
+import { ListBox, MenuTrigger, Text, Tooltip, TooltipTrigger } from 'react-aria-components';
 import { FiMoreHorizontal, FiPlus } from 'react-icons/fi';
 import { Panel, PanelGroup } from 'react-resizable-panels';
 import { twJoin } from 'tailwind-merge';
@@ -128,13 +128,18 @@ function Layout() {
               <CollectionIcon className={tw`size-5 text-slate-500`} />
               <h2 className={tw`text-md flex-1 font-semibold leading-5 tracking-tight text-slate-800`}>Collections</h2>
 
-              <Button
-                className={tw`bg-slate-200 p-0.5`}
-                onPress={() => void collectionCreateMutation.mutate({ name: 'New collection', workspaceId })}
-                variant='ghost'
-              >
-                <FiPlus className={tw`size-4 stroke-[1.2px] text-slate-500`} />
-              </Button>
+              <TooltipTrigger delay={750}>
+                <Button
+                  className={tw`bg-slate-200 p-0.5`}
+                  onPress={() => void collectionCreateMutation.mutate({ name: 'New collection', workspaceId })}
+                  variant='ghost'
+                >
+                  <FiPlus className={tw`size-4 stroke-[1.2px] text-slate-500`} />
+                </Button>
+                <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>
+                  Add New Collection
+                </Tooltip>
+              </TooltipTrigger>
             </div>
 
             <CollectionListTree navigate showControls />
@@ -166,13 +171,16 @@ const FlowList = () => {
         <FlowsIcon className={tw`size-5 text-slate-500`} />
         <h2 className={tw`text-md flex-1 font-semibold leading-5 tracking-tight text-slate-800`}>Flows</h2>
 
-        <Button
-          className={tw`bg-slate-200 p-0.5`}
-          onPress={() => void flowCreateMutation.mutate({ name: 'New flow', workspaceId })}
-          variant='ghost'
-        >
-          <FiPlus className={tw`size-4 stroke-[1.2px] text-slate-500`} />
-        </Button>
+        <TooltipTrigger delay={750}>
+          <Button
+            className={tw`bg-slate-200 p-0.5`}
+            onPress={() => void flowCreateMutation.mutate({ name: 'New flow', workspaceId })}
+            variant='ghost'
+          >
+            <FiPlus className={tw`size-4 stroke-[1.2px] text-slate-500`} />
+          </Button>
+          <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>Add New Flow</Tooltip>
+        </TooltipTrigger>
       </div>
 
       <div className={tw`relative`} ref={listRef}>

--- a/packages/ui/src/add-button.tsx
+++ b/packages/ui/src/add-button.tsx
@@ -1,5 +1,5 @@
 import { pipe, Record, Struct } from 'effect';
-import { Button as AriaButton, ButtonProps as AriaButtonProps } from 'react-aria-components';
+import { Button as AriaButton, ButtonProps as AriaButtonProps, Tooltip, TooltipTrigger } from 'react-aria-components';
 import { FiPlus } from 'react-icons/fi';
 import { tv, VariantProps } from 'tailwind-variants';
 
@@ -39,15 +39,29 @@ export const addButtonVariantKeys = pipe(
 export interface AddButtonVariantProps
   extends Pick<VariantProps<typeof addButtonStyles>, (typeof addButtonVariantKeys)[number]> {}
 
-export interface AddButtonProps extends AddButtonVariantProps, Omit<AriaButtonProps, 'children'> {}
+export interface AddButtonProps extends AddButtonVariantProps, Omit<AriaButtonProps, 'children'> {
+  /** Text to show in the tooltip. If not provided, no tooltip will be shown. */
+  tooltipText?: string;
+}
 
-export const AddButton = ({ className, ...props }: AddButtonProps) => {
+export const AddButton = ({ className, tooltipText, ...props }: AddButtonProps) => {
   const forwardedProps = Struct.omit(props, ...addButtonVariantKeys);
   const variantProps = Struct.pick(props, ...addButtonVariantKeys);
 
-  return (
+  const button = (
     <AriaButton {...forwardedProps} className={composeRenderPropsTV(className, addButtonStyles, variantProps)}>
       <FiPlus className='size-4 stroke-[1.2px]' />
     </AriaButton>
   );
+
+  if (tooltipText) {
+    return (
+      <TooltipTrigger delay={750}>
+        {button}
+        <Tooltip className={tw`rounded-md bg-slate-800 px-2 py-1 text-xs text-white`}>{tooltipText}</Tooltip>
+      </TooltipTrigger>
+    );
+  }
+
+  return button;
 };


### PR DESCRIPTION
- Add tooltips to icon-only buttons throughout the UI
- Set custom delay of 750ms for responsive display
- Add tooltip support to AddButton component
- Remove redundant tooltip from buttons with text labels

By submitting a PR to this repository, you agree to the terms within the [Contributor Covenant Code of Conduct](https://github.com/the-dev-tools/dev-tools/blob/main/docs/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/the-dev-tools/dev-tools/blob/main/docs/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (platform/browser version).

### Checklist

- [ ] I have added a Version Plan for new/changed functionality in this PR
- [ ] All checks for formatting and tests are passing
