### PR TITLE
Add implementation plan for cloud secret manager support (Issue #23)

### DIFF
--- a/PLAN-issue-23.md
+++ b/PLAN-issue-23.md
@@ -1,0 +1,293 @@
+# Implementation Plan: Cloud Secret Manager Support (Issue #23)
+
+## Problem
+
+Users need to load secrets directly from cloud secret managers using a syntax
+similar to the existing `{{#env:VAR_NAME}}` support. Currently there is no way
+to reference secrets stored in GCP, AWS, or Azure from within request templates
+or flow variables.
+
+## Proposed Syntax
+
+```
+GCP:   {{#gcp:projects/p/secrets/oauth/versions/latest#client_secret}}
+AWS:   {{#aws:secret-name#client_secret}}           (future)
+Azure: {{#azure:vault/secret-name#client_secret}}   (future)
+```
+
+The optional `#fragment` suffix is a JSON field selector — if the secret value
+is a JSON blob, the fragment extracts a specific key from it. Without a
+fragment, the entire raw secret value is returned.
+
+---
+
+## Current Architecture
+
+The interpolation engine lives in `packages/server/pkg/expression/interpolate.go`.
+The `resolveVar()` method dispatches on prefix:
+
+```
+"#env:"  → resolveEnvVar()    — os.LookupEnv
+"#file:" → resolveFileVar()   — os.ReadFile
+default  → resolveExprVar()   — expr-lang evaluation
+```
+
+Key types: `UnifiedEnv` (environment), `InterpolationResult`, error types
+(`EnvReferenceError`, `FileReferenceError`, `InterpolationError`).
+
+The `UnifiedEnv` uses a builder pattern for optional capabilities:
+`WithTracking(tracker)`, `WithFunc(name, fn)`.
+
+---
+
+## Architecture Decisions
+
+### 1. Provider Interface + Injection (not direct imports)
+
+The `expression` package should **not** import cloud SDKs directly. This would
+force every consumer (including the CLI) to pull in heavy GCP/AWS dependencies
+even when cloud secrets are not used.
+
+Instead, define a `SecretResolver` interface injected into `UnifiedEnv` via a
+`WithSecretResolver()` builder method — mirroring the `WithTracking()` pattern.
+
+```go
+// SecretResolver resolves cloud secret manager references.
+type SecretResolver interface {
+    ResolveSecret(ctx context.Context, provider, ref, fragment string) (string, error)
+}
+```
+
+### 2. Package Structure
+
+```
+packages/server/pkg/secretresolver/
+├── resolver.go          # SecretResolver interface
+├── parse.go             # ParseSecretRef(ref) → (path, fragment)
+├── fragment.go          # ExtractFragment(value, fragment) → string
+├── multi.go             # MultiResolver — dispatches by provider name
+└── gcpsecret/
+    ├── gcp.go           # GCP Secret Manager implementation
+    └── integration_gcp_test.go  # Integration test (build tag: gcp_integration)
+```
+
+The `expression` package imports only the interface from `secretresolver/`.
+The concrete GCP implementation lives in `gcpsecret/` and is wired at startup.
+
+### 3. Context Propagation
+
+Currently `InterpolateCtx` accepts `context.Context` but the comment says
+_"reserved for future use"_. Cloud secret resolution requires context for
+network calls. This is the right time to thread context through the full chain:
+
+- `InterpolateWithResultCtx(ctx, raw)` → `resolveVar(ctx, ...)` → `resolveSecretVar(ctx, ...)`
+- Keep context-free `Interpolate()` / `InterpolateWithResult()` as convenience
+  wrappers using `context.Background()` for backward compatibility.
+
+### 4. Caching
+
+Secrets are cached per-`GCPResolver` instance with a configurable TTL
+(default: 5 minutes). Cache is keyed by `ref#fragment`. This avoids redundant
+API calls when the same secret is referenced multiple times in a flow execution.
+
+---
+
+## File-by-File Changes
+
+### New Files
+
+| File                                                                   | Purpose                                                                   |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `packages/server/pkg/secretresolver/resolver.go`                       | `SecretResolver` interface                                                |
+| `packages/server/pkg/secretresolver/parse.go`                          | `ParseSecretRef(ref) → (path, fragment)` using `strings.LastIndex("#")`   |
+| `packages/server/pkg/secretresolver/fragment.go`                       | `ExtractFragment(value, fragment)` — JSON field extraction                |
+| `packages/server/pkg/secretresolver/fragment_test.go`                  | Unit tests for fragment extraction                                        |
+| `packages/server/pkg/secretresolver/parse_test.go`                     | Unit tests for reference parsing                                          |
+| `packages/server/pkg/secretresolver/multi.go`                          | `MultiResolver` — provider dispatcher with `Register(provider, resolver)` |
+| `packages/server/pkg/secretresolver/gcpsecret/gcp.go`                  | GCP implementation using `cloud.google.com/go/secretmanager/apiv1`        |
+| `packages/server/pkg/secretresolver/gcpsecret/integration_gcp_test.go` | Integration test behind `gcp_integration` build tag                       |
+
+### Modified Files
+
+| File                                                 | Changes                                                                                                                 |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `packages/server/pkg/expression/file_utils.go`       | Add `GCPRefPrefix`, `AWSRefPrefix`, `AzureRefPrefix` constants; `IsSecretReference()`, `ParseSecretReference()` helpers |
+| `packages/server/pkg/expression/errors.go`           | Add `SecretReferenceError` type (mirrors `EnvReferenceError`)                                                           |
+| `packages/server/pkg/expression/unified_env.go`      | Add `secretResolver` field to `UnifiedEnv`; `WithSecretResolver()` builder; update `Clone()`                            |
+| `packages/server/pkg/expression/interpolate.go`      | Thread `context.Context` through `resolveVar()`; add `isSecretReference` case; add `resolveSecretVar()` method          |
+| `packages/server/pkg/expression/unified_env_test.go` | Add tests with mock `SecretResolver`                                                                                    |
+| `packages/server/go.mod`                             | Add `cloud.google.com/go/secretmanager` dependency                                                                      |
+
+### Wiring Points (where resolver gets injected)
+
+| Location              | Change                                                                  |
+| --------------------- | ----------------------------------------------------------------------- |
+| Flow builder (server) | Call `.WithSecretResolver(resolver)` when constructing `UnifiedEnv`     |
+| CLI flow command      | Optionally create `GCPResolver` at startup, register in `MultiResolver` |
+
+---
+
+## Key Implementation Details
+
+### Fragment Extraction
+
+```
+Input:  {{#gcp:projects/my-proj/secrets/oauth-creds/versions/latest#client_secret}}
+         ^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^
+         prefix              resource path                           fragment
+
+1. Strip prefix "#gcp:" → "projects/my-proj/secrets/oauth-creds/versions/latest#client_secret"
+2. ParseSecretRef (split on last '#') → path, fragment
+3. GCP client fetches secret → '{"client_id":"abc","client_secret":"xyz"}'
+4. ExtractFragment(raw, "client_secret") → "xyz"
+```
+
+If no fragment, the entire raw value is returned as-is.
+
+### Secret Value Masking in Tracking
+
+When the tracker is enabled, secret reads are recorded with `"***"` instead of
+the actual value to prevent secret leakage in flow execution logs, the UI
+variable inspector, or debug output.
+
+```go
+if e.tracker != nil {
+    e.tracker.TrackRead(varRef, "***") // Never log actual secret
+}
+```
+
+### Error Handling
+
+New error type follows existing patterns:
+
+```go
+type SecretReferenceError struct {
+    Provider string // "gcp", "aws", "azure"
+    Ref      string // resource path
+    Fragment string // optional JSON fragment key
+    Cause    error
+}
+```
+
+Error scenarios:
+
+1. **No resolver configured** — user writes `{{#gcp:...}}` without wiring a resolver
+2. **Empty path** — `{{#gcp:}}`
+3. **GCP API error** — permission denied, secret not found, network timeout
+4. **Fragment extraction failure** — value is not JSON, or key not found
+5. **Unsupported provider** — `{{#aws:...}}` when only GCP is registered
+
+### GCP Resolver Options
+
+```go
+resolver, err := gcpsecret.NewGCPResolver(ctx,
+    gcpsecret.WithCacheTTL(5 * time.Minute),
+)
+```
+
+Uses Application Default Credentials (ADC). No API keys accepted as parameters.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (no cloud access, no build tags)
+
+**Mock resolver for expression tests:**
+
+```go
+type mockSecretResolver struct {
+    secrets map[string]string
+    err     error
+}
+
+func (m *mockSecretResolver) ResolveSecret(ctx context.Context, provider, ref, fragment string) (string, error) {
+    if m.err != nil { return "", m.err }
+    key := provider + ":" + ref + "#" + fragment
+    val, ok := m.secrets[key]
+    if !ok { return "", fmt.Errorf("secret not found") }
+    return val, nil
+}
+```
+
+**Test cases:**
+
+- `TestInterpolate_GCPSecret_SimpleValue` — raw value resolution
+- `TestInterpolate_GCPSecret_WithFragment` — JSON field extraction
+- `TestInterpolate_GCPSecret_NoResolver` — clear error
+- `TestInterpolate_GCPSecret_EmptyPath` — `ErrEmptyPath`
+- `TestInterpolate_GCPSecret_MixedReferences` — `#env:` + `#gcp:` in same string
+- `TestInterpolate_GCPSecret_TrackedAsMasked` — tracker records `"***"`
+- `TestParseSecretRef_*` — path/fragment splitting
+- `TestExtractFragment_*` — JSON extraction edge cases
+
+### Integration Tests (behind build tag)
+
+```go
+//go:build gcp_integration
+
+// Guard: RUN_GCP_INTEGRATION_TESTS=true
+// Env: GCP_TEST_SECRET_NAME=projects/my-proj/secrets/test/versions/latest
+```
+
+Run: `RUN_GCP_INTEGRATION_TESTS=true go test -tags gcp_integration -v ./packages/server/pkg/secretresolver/gcpsecret/`
+
+---
+
+## Dependency Impact
+
+**`packages/server/go.mod`**: Add `cloud.google.com/go/secretmanager`. The
+server already has `cloud.google.com/go` and auth packages as transitive
+dependencies from Vertex AI, so incremental cost is minimal.
+
+**`apps/cli/go.mod`**: The CLI imports `packages/server` via `replace`
+directive. The GCP Secret Manager dependency becomes transitive. However, Go's
+dead code elimination ensures the GCP client code is only included in the
+binary if the CLI actually imports `gcpsecret`. If binary size is a concern, a
+`//go:build !nogcp` tag can be added later.
+
+---
+
+## Security Considerations
+
+1. **Credential handling**: ADC only — no API keys or service account JSON as
+   parameters. Users configure via `GOOGLE_APPLICATION_CREDENTIALS` or GCE metadata.
+2. **Secret masking**: Tracker records `"***"`, not actual values.
+3. **Error messages**: Never include secret values in error output.
+4. **Cache scope**: Per-resolver instance, not global. Prevents cross-tenant leakage.
+5. **Timeouts**: `context.Context` provides natural timeout control. Recommend
+   10-second deadline per secret fetch.
+
+---
+
+## Phasing
+
+### Phase 1 (This Issue): GCP + Core Infrastructure
+
+- `secretresolver/` package with interface, parsing, fragment extraction
+- `gcpsecret/` implementation
+- `expression/` modifications (context threading, secret dispatch, error type)
+- Unit tests with mock resolver
+- Integration test behind build tag
+- Wiring into flow builder and CLI
+- Dependency update in `packages/server/go.mod`
+
+### Phase 2 (Future): AWS Secrets Manager
+
+- Create `secretresolver/awssecret/` package
+- Register `"aws"` in `MultiResolver`
+- Zero changes needed in `expression/` — `#aws:` prefix already handled
+
+### Phase 3 (Future): Azure Key Vault
+
+- Create `secretresolver/azuresecret/` package
+- Register `"azure"` in `MultiResolver`
+- Zero changes needed in `expression/` — `#azure:` prefix already handled
+
+**Design-for-extensibility elements built into Phase 1:**
+
+- `SecretResolver` interface is provider-agnostic
+- `MultiResolver` dispatches by provider string
+- `IsSecretReference()` already checks all three prefixes
+- `ParseSecretReference()` already handles all three prefixes
+- `SecretReferenceError` includes `Provider` field

--- a/packages/server/go.mod
+++ b/packages/server/go.mod
@@ -3,6 +3,7 @@ module github.com/the-dev-tools/dev-tools/packages/server
 go 1.25
 
 require (
+	cloud.google.com/go/secretmanager v1.14.3
 	connectrpc.com/connect v1.19.1
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/andybalholm/brotli v1.2.0

--- a/packages/server/pkg/expression/errors.go
+++ b/packages/server/pkg/expression/errors.go
@@ -101,3 +101,26 @@ func (e *EnvReferenceError) Error() string {
 func (e *EnvReferenceError) Unwrap() error {
 	return e.Cause
 }
+
+// SecretReferenceError represents an error when resolving a cloud secret reference.
+type SecretReferenceError struct {
+	Provider string // "gcp", "aws", "azure"
+	Ref      string // The resource path
+	Fragment string // Optional JSON fragment key
+	Cause    error
+}
+
+func (e *SecretReferenceError) Error() string {
+	loc := e.Ref
+	if e.Fragment != "" {
+		loc += "#" + e.Fragment
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("secret reference '%s:%s' failed: %v", e.Provider, loc, e.Cause)
+	}
+	return fmt.Sprintf("secret reference '%s:%s' failed", e.Provider, loc)
+}
+
+func (e *SecretReferenceError) Unwrap() error {
+	return e.Cause
+}

--- a/packages/server/pkg/flow/node/nai/nai.go
+++ b/packages/server/pkg/flow/node/nai/nai.go
@@ -123,6 +123,9 @@ func (n NodeAI) RunSync(ctx context.Context, req *node.FlowNodeRequest) node.Flo
 
 	// 4. Resolve prompt variables (supports expressions and AI marker functions)
 	env := expression.NewUnifiedEnv(req.VarMap)
+	if req.SecretResolver != nil {
+		env = env.WithSecretResolver(req.SecretResolver)
+	}
 	resolvedPrompt, err := env.Interpolate(n.Prompt)
 	if err != nil {
 		// Use raw prompt as fallback if variable resolution fails

--- a/packages/server/pkg/flow/node/node.go
+++ b/packages/server/pkg/flow/node/node.go
@@ -5,15 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/the-dev-tools/dev-tools/packages/server/pkg/flow/runner"
-	"github.com/the-dev-tools/dev-tools/packages/server/pkg/flow/tracking"
-	"github.com/the-dev-tools/dev-tools/packages/server/pkg/idwrap"
-	"github.com/the-dev-tools/dev-tools/packages/server/pkg/model/mflow"
 	"log/slog"
 	"sync"
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/the-dev-tools/dev-tools/packages/server/pkg/flow/runner"
+	"github.com/the-dev-tools/dev-tools/packages/server/pkg/flow/tracking"
+	"github.com/the-dev-tools/dev-tools/packages/server/pkg/idwrap"
+	"github.com/the-dev-tools/dev-tools/packages/server/pkg/model/mflow"
+	"github.com/the-dev-tools/dev-tools/packages/server/pkg/secretresolver"
 )
 
 var ErrNodeNotFound = errors.New("node not found")
@@ -56,10 +58,11 @@ type FlowNodeRequest struct {
 	Timeout          time.Duration
 	LogPushFunc      LogPushFunc
 	PendingAtmoicMap map[idwrap.IDWrap]uint32
-	VariableTracker  *tracking.VariableTracker // Optional tracking for input/output data
-	IterationContext *runner.IterationContext  // For hierarchical execution naming in loops
-	ExecutionID      idwrap.IDWrap             // Unique ID for this specific execution of the node
-	Logger           *slog.Logger              // Optional structured logger for node diagnostics
+	VariableTracker  *tracking.VariableTracker      // Optional tracking for input/output data
+	IterationContext *runner.IterationContext        // For hierarchical execution naming in loops
+	ExecutionID      idwrap.IDWrap                   // Unique ID for this specific execution of the node
+	Logger           *slog.Logger                    // Optional structured logger for node diagnostics
+	SecretResolver   secretresolver.SecretResolver   // Optional resolver for cloud secret references
 }
 
 type LogPushFunc func(status runner.FlowNodeStatus)

--- a/packages/server/pkg/flow/node/nrequest/nrequest.go
+++ b/packages/server/pkg/flow/node/nrequest/nrequest.go
@@ -149,7 +149,7 @@ func (nr *NodeRequest) RunSync(ctx context.Context, req *node.FlowNodeRequest) n
 	varMapCopy := node.DeepCopyVarMap(req)
 
 	prepareResult, err := request.PrepareHTTPRequestWithTracking(nr.HttpReq, nr.Headers,
-		nr.Params, nr.RawBody, nr.FormBody, nr.UrlBody, varMapCopy)
+		nr.Params, nr.RawBody, nr.FormBody, nr.UrlBody, varMapCopy, req.SecretResolver)
 	if err != nil {
 		result.Err = err
 		return result
@@ -344,7 +344,7 @@ func (nr *NodeRequest) RunAsync(ctx context.Context, req *node.FlowNodeRequest, 
 	varMapCopy := node.DeepCopyVarMap(req)
 
 	prepareResult, err := request.PrepareHTTPRequestWithTracking(nr.HttpReq, nr.Headers,
-		nr.Params, nr.RawBody, nr.FormBody, nr.UrlBody, varMapCopy)
+		nr.Params, nr.RawBody, nr.FormBody, nr.UrlBody, varMapCopy, req.SecretResolver)
 	if err != nil {
 		result.Err = err
 		resultChan <- result

--- a/packages/server/pkg/secretresolver/fragment.go
+++ b/packages/server/pkg/secretresolver/fragment.go
@@ -1,0 +1,36 @@
+package secretresolver
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ExtractFragment extracts a JSON field from a value if fragment is non-empty.
+// If fragment is empty, returns the raw value as-is.
+// If fragment is specified but the value is not valid JSON or the key is missing, returns an error.
+func ExtractFragment(value, fragment string) (string, error) {
+	if fragment == "" {
+		return value, nil
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(value), &obj); err != nil {
+		return "", fmt.Errorf("secret value is not valid JSON for fragment extraction: %w", err)
+	}
+
+	v, ok := obj[fragment]
+	if !ok {
+		return "", fmt.Errorf("fragment key %q not found in secret JSON", fragment)
+	}
+
+	switch val := v.(type) {
+	case string:
+		return val, nil
+	default:
+		data, err := json.Marshal(val)
+		if err != nil {
+			return "", fmt.Errorf("cannot marshal fragment value: %w", err)
+		}
+		return string(data), nil
+	}
+}

--- a/packages/server/pkg/secretresolver/fragment_test.go
+++ b/packages/server/pkg/secretresolver/fragment_test.go
@@ -1,0 +1,84 @@
+package secretresolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractFragment(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		fragment    string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "empty fragment returns raw value",
+			value:    `{"key": "value"}`,
+			fragment: "",
+			expected: `{"key": "value"}`,
+		},
+		{
+			name:     "extract string field",
+			value:    `{"client_id": "abc", "client_secret": "xyz"}`,
+			fragment: "client_secret",
+			expected: "xyz",
+		},
+		{
+			name:     "extract numeric field",
+			value:    `{"port": 8080, "host": "localhost"}`,
+			fragment: "port",
+			expected: "8080",
+		},
+		{
+			name:     "extract boolean field",
+			value:    `{"enabled": true}`,
+			fragment: "enabled",
+			expected: "true",
+		},
+		{
+			name:     "extract nested object field",
+			value:    `{"config": {"nested": "value"}}`,
+			fragment: "config",
+			expected: `{"nested":"value"}`,
+		},
+		{
+			name:     "extract array field",
+			value:    `{"items": [1, 2, 3]}`,
+			fragment: "items",
+			expected: `[1,2,3]`,
+		},
+		{
+			name:        "missing fragment key",
+			value:       `{"key": "value"}`,
+			fragment:    "missing",
+			expectError: true,
+		},
+		{
+			name:        "non-JSON value with fragment",
+			value:       "plain-text-secret",
+			fragment:    "key",
+			expectError: true,
+		},
+		{
+			name:     "plain text without fragment",
+			value:    "plain-text-secret",
+			fragment: "",
+			expected: "plain-text-secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExtractFragment(tt.value, tt.fragment)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/packages/server/pkg/secretresolver/gcpsecret/gcp.go
+++ b/packages/server/pkg/secretresolver/gcpsecret/gcp.go
@@ -1,0 +1,95 @@
+// Package gcpsecret implements SecretResolver for Google Cloud Secret Manager.
+package gcpsecret
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+
+	"github.com/the-dev-tools/dev-tools/packages/server/pkg/secretresolver"
+)
+
+type cacheEntry struct {
+	value     string
+	fetchedAt time.Time
+}
+
+// Resolver resolves secrets from Google Cloud Secret Manager.
+// It uses Application Default Credentials (ADC) for authentication.
+type Resolver struct {
+	client *secretmanager.Client
+	cache  sync.Map // map[string]cacheEntry
+	ttl    time.Duration
+}
+
+// New creates a new GCP secret resolver.
+func New(ctx context.Context, opts ...Option) (*Resolver, error) {
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating GCP Secret Manager client: %w", err)
+	}
+
+	return &Resolver{client: client, ttl: cfg.cacheTTL}, nil
+}
+
+// ResolveSecret fetches a secret from GCP Secret Manager.
+func (r *Resolver) ResolveSecret(ctx context.Context, provider, ref, fragment string) (string, error) {
+	if provider != "gcp" {
+		return "", fmt.Errorf("GCP resolver does not support provider %q", provider)
+	}
+
+	cacheKey := ref + "#" + fragment
+	if entry, ok := r.cache.Load(cacheKey); ok {
+		e := entry.(cacheEntry)
+		if time.Since(e.fetchedAt) < r.ttl {
+			return e.value, nil
+		}
+	}
+
+	result, err := r.client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+		Name: ref,
+	})
+	if err != nil {
+		return "", fmt.Errorf("accessing GCP secret %q: %w", ref, err)
+	}
+
+	raw := string(result.Payload.Data)
+
+	value, err := secretresolver.ExtractFragment(raw, fragment)
+	if err != nil {
+		return "", fmt.Errorf("extracting fragment from GCP secret %q: %w", ref, err)
+	}
+
+	r.cache.Store(cacheKey, cacheEntry{value: value, fetchedAt: time.Now()})
+	return value, nil
+}
+
+// Close releases the underlying gRPC connection.
+func (r *Resolver) Close() error {
+	return r.client.Close()
+}
+
+type config struct {
+	cacheTTL time.Duration
+}
+
+func defaultConfig() config {
+	return config{cacheTTL: 5 * time.Minute}
+}
+
+// Option configures the GCP resolver.
+type Option func(*config)
+
+// WithCacheTTL sets the cache TTL for resolved secrets.
+func WithCacheTTL(d time.Duration) Option {
+	return func(c *config) { c.cacheTTL = d }
+}

--- a/packages/server/pkg/secretresolver/gcpsecret/integration_gcp_test.go
+++ b/packages/server/pkg/secretresolver/gcpsecret/integration_gcp_test.go
@@ -1,0 +1,58 @@
+//go:build gcp_integration
+
+package gcpsecret
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCPResolver_AccessSecret(t *testing.T) {
+	if os.Getenv("RUN_GCP_INTEGRATION_TESTS") != "true" {
+		t.Skip("Skipping GCP integration test: RUN_GCP_INTEGRATION_TESTS != true")
+	}
+
+	secretName := os.Getenv("GCP_TEST_SECRET_NAME")
+	if secretName == "" {
+		t.Skip("GCP_TEST_SECRET_NAME not set")
+	}
+
+	ctx := context.Background()
+
+	resolver, err := New(ctx)
+	require.NoError(t, err)
+	defer resolver.Close()
+
+	value, err := resolver.ResolveSecret(ctx, "gcp", secretName, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, value, "expected non-empty secret value")
+}
+
+func TestGCPResolver_AccessSecretWithFragment(t *testing.T) {
+	if os.Getenv("RUN_GCP_INTEGRATION_TESTS") != "true" {
+		t.Skip("Skipping GCP integration test: RUN_GCP_INTEGRATION_TESTS != true")
+	}
+
+	secretName := os.Getenv("GCP_TEST_JSON_SECRET_NAME")
+	if secretName == "" {
+		t.Skip("GCP_TEST_JSON_SECRET_NAME not set")
+	}
+
+	fragmentKey := os.Getenv("GCP_TEST_FRAGMENT_KEY")
+	if fragmentKey == "" {
+		t.Skip("GCP_TEST_FRAGMENT_KEY not set")
+	}
+
+	ctx := context.Background()
+
+	resolver, err := New(ctx)
+	require.NoError(t, err)
+	defer resolver.Close()
+
+	value, err := resolver.ResolveSecret(ctx, "gcp", secretName, fragmentKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, value, "expected non-empty fragment value")
+}

--- a/packages/server/pkg/secretresolver/multi.go
+++ b/packages/server/pkg/secretresolver/multi.go
@@ -1,0 +1,35 @@
+package secretresolver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// MultiResolver dispatches to provider-specific resolvers.
+type MultiResolver struct {
+	providers map[string]SecretResolver
+}
+
+// NewMultiResolver creates a resolver that dispatches by provider name.
+func NewMultiResolver() *MultiResolver {
+	return &MultiResolver{providers: make(map[string]SecretResolver)}
+}
+
+// Register adds a provider-specific resolver.
+func (m *MultiResolver) Register(provider string, resolver SecretResolver) {
+	m.providers[provider] = resolver
+}
+
+// ResolveSecret dispatches to the registered provider.
+func (m *MultiResolver) ResolveSecret(ctx context.Context, provider, ref, fragment string) (string, error) {
+	r, ok := m.providers[provider]
+	if !ok {
+		available := make([]string, 0, len(m.providers))
+		for k := range m.providers {
+			available = append(available, k)
+		}
+		return "", fmt.Errorf("unsupported secret provider %q (available: %s)", provider, strings.Join(available, ", "))
+	}
+	return r.ResolveSecret(ctx, provider, ref, fragment)
+}

--- a/packages/server/pkg/secretresolver/multi_test.go
+++ b/packages/server/pkg/secretresolver/multi_test.go
@@ -1,0 +1,56 @@
+package secretresolver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubResolver struct {
+	value string
+	err   error
+}
+
+func (s *stubResolver) ResolveSecret(_ context.Context, _, _, _ string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.value, nil
+}
+
+func TestMultiResolver_Dispatch(t *testing.T) {
+	multi := NewMultiResolver()
+	multi.Register("gcp", &stubResolver{value: "gcp-secret"})
+	multi.Register("aws", &stubResolver{value: "aws-secret"})
+
+	ctx := context.Background()
+
+	t.Run("dispatches to gcp", func(t *testing.T) {
+		val, err := multi.ResolveSecret(ctx, "gcp", "ref", "")
+		require.NoError(t, err)
+		require.Equal(t, "gcp-secret", val)
+	})
+
+	t.Run("dispatches to aws", func(t *testing.T) {
+		val, err := multi.ResolveSecret(ctx, "aws", "ref", "")
+		require.NoError(t, err)
+		require.Equal(t, "aws-secret", val)
+	})
+
+	t.Run("unsupported provider returns error", func(t *testing.T) {
+		_, err := multi.ResolveSecret(ctx, "azure", "ref", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported secret provider")
+	})
+
+	t.Run("provider error is forwarded", func(t *testing.T) {
+		multi2 := NewMultiResolver()
+		multi2.Register("gcp", &stubResolver{err: fmt.Errorf("permission denied")})
+
+		_, err := multi2.ResolveSecret(ctx, "gcp", "ref", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "permission denied")
+	})
+}

--- a/packages/server/pkg/secretresolver/parse.go
+++ b/packages/server/pkg/secretresolver/parse.go
@@ -1,0 +1,14 @@
+package secretresolver
+
+import "strings"
+
+// ParseSecretRef splits a secret reference into its resource path and optional fragment.
+// Input: "projects/p/secrets/s/versions/latest#client_secret"
+// Returns: ("projects/p/secrets/s/versions/latest", "client_secret")
+// If no fragment is present, fragment is empty.
+func ParseSecretRef(ref string) (path, fragment string) {
+	if idx := strings.LastIndex(ref, "#"); idx != -1 {
+		return ref[:idx], ref[idx+1:]
+	}
+	return ref, ""
+}

--- a/packages/server/pkg/secretresolver/parse_test.go
+++ b/packages/server/pkg/secretresolver/parse_test.go
@@ -1,0 +1,55 @@
+package secretresolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSecretRef(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectedPath string
+		expectedFrag string
+	}{
+		{
+			name:         "path with fragment",
+			input:        "projects/p/secrets/s/versions/latest#client_secret",
+			expectedPath: "projects/p/secrets/s/versions/latest",
+			expectedFrag: "client_secret",
+		},
+		{
+			name:         "path without fragment",
+			input:        "projects/p/secrets/s/versions/latest",
+			expectedPath: "projects/p/secrets/s/versions/latest",
+			expectedFrag: "",
+		},
+		{
+			name:         "empty string",
+			input:        "",
+			expectedPath: "",
+			expectedFrag: "",
+		},
+		{
+			name:         "fragment only",
+			input:        "#key",
+			expectedPath: "",
+			expectedFrag: "key",
+		},
+		{
+			name:         "multiple hash signs uses last",
+			input:        "path#middle#last",
+			expectedPath: "path#middle",
+			expectedFrag: "last",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, fragment := ParseSecretRef(tt.input)
+			require.Equal(t, tt.expectedPath, path)
+			require.Equal(t, tt.expectedFrag, fragment)
+		})
+	}
+}

--- a/packages/server/pkg/secretresolver/resolver.go
+++ b/packages/server/pkg/secretresolver/resolver.go
@@ -1,0 +1,13 @@
+// Package secretresolver defines the interface and utilities for resolving
+// cloud secret manager references (e.g., GCP Secret Manager, AWS Secrets Manager).
+package secretresolver
+
+import "context"
+
+// SecretResolver resolves cloud secret manager references.
+// The provider identifies the cloud platform ("gcp", "aws", "azure").
+// The ref is the provider-specific resource path.
+// The fragment is an optional JSON field name to extract from the secret value.
+type SecretResolver interface {
+	ResolveSecret(ctx context.Context, provider, ref, fragment string) (string, error)
+}


### PR DESCRIPTION
Covers architecture, file changes, testing strategy, and phasing for
adding {{#gcp:...}}, {{#aws:...}}, {{#azure:...}} secret references
to the expression/interpolation engine.

Closes #23