### PR TITLE
fix(ci): unmask release build failures and fix the ui:lint synckit crash

### DIFF
--- a/.github/actions/dependencies-unix/action.yaml
+++ b/.github/actions/dependencies-unix/action.yaml
@@ -1,5 +1,5 @@
 name: Setup Unix dependencies
-description: ''
+description: Install the Nix toolchain and expose the flake devshell to later steps.
 
 runs:
   using: composite

--- a/.github/actions/dependencies-windows/action.yaml
+++ b/.github/actions/dependencies-windows/action.yaml
@@ -1,5 +1,5 @@
 name: Setup Windows dependencies
-description: ''
+description: Install the Scoop build toolchain and AzureSignTool, and pin pnpm to the version the Nix flake uses elsewhere.
 
 runs:
   using: composite

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,5 +1,5 @@
 name: Setup runner
-description: ''
+description: Install the platform toolchain, Node and Go, then restore workspace and Go tool dependencies.
 
 inputs:
   shell:

--- a/.github/workflows/benchmark-generic.yml
+++ b/.github/workflows/benchmark-generic.yml
@@ -187,6 +187,12 @@ jobs:
     name: Post Results Comment
     runs-on: ubuntu-latest
     needs: benchmark
+    # This job never actually ran until the `github.event_name` guard below was
+    # repaired, so it never needed a token that could write. The repository
+    # default is read-only, which would now turn every benchmarked PR into a 403
+    # on issues.createComment. The job only reads and writes PR comments.
+    permissions:
+      pull-requests: write
     if: |
       always() && 
       needs.benchmark.result == 'success' && 

--- a/.github/workflows/benchmark-generic.yml
+++ b/.github/workflows/benchmark-generic.yml
@@ -191,7 +191,7 @@ jobs:
       always() && 
       needs.benchmark.result == 'success' && 
       needs.benchmark.outputs.has-changes == 'true' &&
-      github.com.event_name == 'pull_request'
+      github.event_name == 'pull_request'
     steps:
       - name: Find and update PR comment
         uses: actions/github-script@v7

--- a/.github/workflows/release-electron-builder.yaml
+++ b/.github/workflows/release-electron-builder.yaml
@@ -6,8 +6,12 @@ on:
 jobs:
   build:
     name: Build
-    continue-on-error: true
+    # See release-go.yaml for the full rationale. Same defect, same fix: a
+    # masked failure here silently ships a desktop release missing an installer
+    # for whichever platform broke. fail-fast: false keeps the rows independent
+    # so one failure cannot cancel the others (notarization alone runs long).
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - macos-15-intel # x64

--- a/.github/workflows/release-go.yaml
+++ b/.github/workflows/release-go.yaml
@@ -6,8 +6,18 @@ on:
 jobs:
   build:
     name: Build Go Binary
-    continue-on-error: true
+    # Deliberately no `continue-on-error: true`. It used to be set here, which
+    # forced every row's conclusion to success even when the build died, so
+    # cli@1.1.0 published 4 of its 6 assets behind a green check and the two
+    # broken Windows rows went unnoticed until someone opened the logs by hand.
+    # A release that cannot produce an asset must fail the run that publishes it.
+    #
+    # fail-fast: false preserves the one useful thing continue-on-error was
+    # doing by accident: rows stay independent. Without it, the first failing
+    # target would cancel the five healthy ones still in flight — including the
+    # ~20 minute darwin-x64 build — and strand the release half-published.
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runner: macos-15-intel

--- a/.github/workflows/sql.yml
+++ b/.github/workflows/sql.yml
@@ -10,7 +10,7 @@ jobs:
     name: SQL Vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: sqlc-dev/setup-sqlc@v4
         with:
           sqlc-version: '1.30.0'

--- a/nx.json
+++ b/nx.json
@@ -23,7 +23,21 @@
     },
 
     "lint": {
-      "dependsOn": ["^pre-lint", "pre-lint"]
+      "dependsOn": ["^pre-lint", "pre-lint"],
+
+      // eslint-plugin-better-tailwindcss resolves the Tailwind design system in a
+      // synckit worker and blocks on Atomics.wait(). Building that context for
+      // packages/ui/src/styles/index.css is a cold, CPU-bound compile that the
+      // plugin caps at 30s. On a 4-vCPU CI runner with several lint targets in
+      // flight it overran the cap and ESLint died with
+      //   Internal error: Atomics.wait() failed: timed-out
+      // failing main at random. Raise the ceiling; it is a deadline, not a budget,
+      // so a healthy run never waits any longer than it does today.
+      "options": {
+        "env": {
+          "SYNCKIT_TIMEOUT": "120000"
+        }
+      }
     },
 
     "test": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ catalogs:
       specifier: 4.4.4
       version: 4.4.4
     eslint-plugin-better-tailwindcss:
-      specifier: 4.3.2
-      version: 4.3.2
+      specifier: 4.4.0
+      version: 4.4.0
     eslint-plugin-import-x:
       specifier: 4.16.1
       version: 4.16.1
@@ -1071,7 +1071,7 @@ importers:
         version: 4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-better-tailwindcss:
         specifier: 'catalog:'
-        version: 4.3.2(eslint@9.39.2(jiti@2.6.1))(tailwindcss@4.2.1)(typescript@5.9.3)
+        version: 4.4.0(eslint@9.39.2(jiti@2.6.1))(tailwindcss@4.2.1)(typescript@5.9.3)
       eslint-plugin-import-x:
         specifier: 'catalog:'
         version: 4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))
@@ -2650,9 +2650,9 @@ packages:
     resolution: {integrity: sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/css-tree@3.6.9':
-    resolution: {integrity: sha512-3D5/OHibNEGk+wKwNwMbz63NMf367EoR4mVNNpxddCHKEb2Nez7z62J2U6YjtErSsZDoY0CsccmoUpdEbkogNA==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+  '@eslint/css-tree@4.0.5':
+    resolution: {integrity: sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/eslintrc@3.3.4':
     resolution: {integrity: sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==}
@@ -5443,10 +5443,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@valibot/to-json-schema@1.5.0':
-    resolution: {integrity: sha512-GE7DmSr1C2UCWPiV0upRH6mv0cCPsqYGs819fb6srCS1tWhyXrkGGe+zxUiwzn/L1BOfADH4sNjY/YHCuP8phQ==}
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
     peerDependencies:
-      valibot: ^1.2.0
+      valibot: ^1.4.0
 
   '@vitejs/plugin-react@5.1.4':
     resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
@@ -6981,6 +6981,10 @@ packages:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
+
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
@@ -7105,8 +7109,8 @@ packages:
       eslint-plugin-import-x:
         optional: true
 
-  eslint-plugin-better-tailwindcss@4.3.2:
-    resolution: {integrity: sha512-1DLX2QmHmOj3u667f8vEI0zKoRc0Y1qJt33tfIeIkpTyzWaz9b2GzWBLD4bR+WJ/kxzC0Skcbx7cMerRWQ6OYg==}
+  eslint-plugin-better-tailwindcss@4.4.0:
+    resolution: {integrity: sha512-OVFcRnyFOMJR7dFhlfNbIBlM7D4o1g1yBGDCWvsJWliXFE4c4U06CEZ0pcFatHa5g7PAwiDRAd57gxxJT/7EIQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -8491,8 +8495,8 @@ packages:
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
-  mdn-data@2.23.0:
-    resolution: {integrity: sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==}
+  mdn-data@2.29.0:
+    resolution: {integrity: sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -10171,9 +10175,14 @@ packages:
     engines: {node: '>=18.18.0'}
     hasBin: true
 
-  tailwind-csstree@0.1.4:
-    resolution: {integrity: sha512-FzD187HuFIZEyeR7Xy6sJbJll2d4SybS90satC8SKIuaNRC05CxMvdzN7BUsfDQffcnabckRM5OIcfArjsZ0mg==}
+  tailwind-csstree@0.3.3:
+    resolution: {integrity: sha512-je9J5UYRsTJqAjYrIBMMlge8T/rreRd44pJxgG5Zx/zeo4kAC/liUKqzztRZrGlYRJLvIf2Cb1DVJMTXSzEShA==}
     engines: {node: '>=18.18'}
+    peerDependencies:
+      '@eslint/css': '>=1.0.0'
+    peerDependenciesMeta:
+      '@eslint/css':
+        optional: true
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -10198,6 +10207,10 @@ packages:
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-fs@2.1.4:
@@ -10647,6 +10660,14 @@ packages:
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -12770,9 +12791,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/css-tree@3.6.9':
+  '@eslint/css-tree@4.0.5':
     dependencies:
-      mdn-data: 2.23.0
+      mdn-data: 2.29.0
       source-map-js: 1.2.1
 
   '@eslint/eslintrc@3.3.4':
@@ -16446,9 +16467,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3))':
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@5.9.3))':
     dependencies:
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
 
   '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -18127,6 +18148,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   enquirer@2.3.6:
     dependencies:
       ansi-colors: 4.1.3
@@ -18350,20 +18376,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-better-tailwindcss@4.3.2(eslint@9.39.2(jiti@2.6.1))(tailwindcss@4.2.1)(typescript@5.9.3):
+  eslint-plugin-better-tailwindcss@4.4.0(eslint@9.39.2(jiti@2.6.1))(tailwindcss@4.2.1)(typescript@5.9.3):
     dependencies:
-      '@eslint/css-tree': 3.6.9
-      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.9.3))
-      enhanced-resolve: 5.20.0
+      '@eslint/css-tree': 4.0.5
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@5.9.3))
+      enhanced-resolve: 5.24.5
       jiti: 2.6.1
       synckit: 0.11.12
-      tailwind-csstree: 0.1.4
+      tailwind-csstree: 0.3.3
       tailwindcss: 4.2.1
       tsconfig-paths-webpack-plugin: 4.2.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
     transitivePeerDependencies:
+      - '@eslint/css'
       - typescript
 
   eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)):
@@ -19987,7 +20014,7 @@ snapshots:
 
   mdn-data@2.0.30: {}
 
-  mdn-data@2.23.0: {}
+  mdn-data@2.29.0: {}
 
   media-typer@0.3.0: {}
 
@@ -22116,7 +22143,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  tailwind-csstree@0.1.4: {}
+  tailwind-csstree@0.3.3: {}
 
   tailwind-merge@3.5.0: {}
 
@@ -22133,6 +22160,8 @@ snapshots:
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
+
+  tapable@2.3.3: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -22340,7 +22369,7 @@ snapshots:
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.20.0
+      enhanced-resolve: 5.24.5
       tapable: 2.3.0
       tsconfig-paths: 4.2.0
 
@@ -22639,6 +22668,11 @@ snapshots:
   v8-compile-cache-lib@3.0.1: {}
 
   valibot@1.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,7 +90,11 @@ catalog:
   eslint: 9.39.2
   eslint-config-prettier: 10.1.8
   eslint-import-resolver-typescript: 4.4.4
-  eslint-plugin-better-tailwindcss: 4.3.2
+  # 4.4.0 is the first release whose synckit worker honours SYNCKIT_TIMEOUT
+  # (4.3.2 hardcoded 30s and passed it explicitly to createSyncFn, which
+  # overrode synckit's own default, so the env var was silently ignored).
+  # nx.json raises that timeout for lint targets — see the note there.
+  eslint-plugin-better-tailwindcss: 4.4.0
   eslint-plugin-import-x: 4.16.1
   eslint-plugin-jsx-a11y: 6.10.2
   eslint-plugin-perfectionist: 5.6.0


### PR DESCRIPTION
Fixes the two failing Windows release jobs from [run 31281026143](https://github.com/the-dev-tools/dev-tools/actions/runs/31281026143), the reason nobody noticed them, and the flake that has been reddening `main`.

## 1. Release runs reported green while builds failed

Both release workflows set `continue-on-error: true` on the matrix build job, forcing every row's conclusion to success even when the build died. `cli@1.1.0` shipped that way — the two Windows rows failed on an unexpanded `${PLATFORM}`, published nothing, and the run still showed a green check.

Dropped it, and added `fail-fast: false` in the same move. That pairing matters: `fail-fast: false` is what keeps rows independent once `continue-on-error` is gone. Without it the first failing target would cancel the healthy rows still in flight — including the ~20 minute `darwin-x64` build — and strand the release half-published.

Applied to `release-electron-builder.yaml` too, which had the identical latent bug.

**The underlying build bug is already fixed** (`454fd20f`) and shipped as `cli@1.1.1`. Verified by downloading every published asset:

```
darwin-arm64      Mach-O 64-bit arm64
darwin-x64        Mach-O 64-bit x86_64
linux-arm64       ELF 64-bit ARM aarch64
linux-x64         ELF 64-bit x86-64
win32-ia32.exe    PE32 Intel 80386
win32-x64.exe     PE32+ x86-64
```

Correct architectures, not mislabeled x64 copies. This PR fixes the _reporting_, so the next partial release fails loudly instead of publishing quietly.

## 2. `ui:lint` crashing on main

Not a lint finding — a hard ESLint abort:

```
Internal error: Atomics.wait() failed: timed-out
Rule: "better-tailwindcss/enforce-canonical-classes"
```

`eslint-plugin-better-tailwindcss` resolves the Tailwind design system in a synckit worker and blocks on `Atomics.wait()`. Building that context for `packages/ui/src/styles/index.css` is a cold, CPU-bound compile capped at 30s. On a 4-vCPU runner with several lint targets in flight, that ceiling gets crossed and ESLint aborts, failing `task lint` (and `--nxBail` skips the rest of the run).

4.3.2 passed `timeout: 30000` explicitly to `createSyncFn`, which **overrides** synckit's own default — so `SYNCKIT_TIMEOUT` was silently ignored and there was no way to raise it. 4.4.0 is the first release that reads the env var. Its recommended preset is otherwise unchanged: the two rules it adds are both `recommended: false`, so the effective rule set does not move.

Verified the plumbing by falsification — forcing `SYNCKIT_TIMEOUT=1` reproduces the exact CI error locally, proving the var now reaches the plugin and controls that timeout.

## 3. Benchmark PR comments have never worked

The comment job guarded on `github.com.event_name == 'pull_request'`. There is no `com` property on the github context, so the expression evaluates to null, never matches, and **the job has silently never run**.

Fixing the guard alone would have made things worse: the workflow declares no `permissions:` block and this repo's default `GITHUB_TOKEN` is read-only, so the job went straight to `403 Resource not accessible by integration` — [observed on the first push of this branch](https://github.com/the-dev-tools/dev-tools/actions/runs/31316806703). Granting `pull-requests: write` at the job level fixes it; the job only reads and writes PR comments and never checks out the repo.

The performance-comparison comment on this PR is that job working for the first time.

## 4. Remaining actionlint findings

`.github` is now actionlint-clean. `sql.yml` still pinned `actions/checkout@v3`, whose runner GitHub no longer supports, and the three composite actions carried empty `description` fields.

## Verification

- `task lint` — green, 15 projects, `lint` + `lint:format`, including `server:lint` (golangci-lint, norawsql, notxread)
- `actionlint` — clean across all workflows
- `prettier --check` — clean on every changed file
- Workflow YAML re-parsed to confirm matrix rows and steps are structurally unchanged (6 rows/5 steps go, 4 rows/8 steps electron)
- Generic Benchmark CI green on this branch, with the comment job succeeding

## Not addressed, deliberately

`cli@1.1.0` remains published with 4 of 6 assets, and already carries a release note pointing Windows users at `cli@1.1.1` (which is marked Latest and complete). Backfilling would mean uploading locally-built binaries with different provenance than the rest of the release, and re-cutting a shipped tag is worse. Left as an accurate historical record.

No visual surface — CI configuration and a dependency bump only.
